### PR TITLE
🐛 fix file handler issue when running as cli

### DIFF
--- a/mergesvvcf/mergedfile.py
+++ b/mergesvvcf/mergedfile.py
@@ -270,8 +270,9 @@ def merge(
         "String",
         "Strand orientation of the adjacency in BEDPE format (DEL:+-, DUP:-+, INV:++/--)",
     )
-
-    outfile = open(outfile,'w')
+    # outfile should be a file handler. if it's a file name open it
+    if isinstance(outfile, str):
+        outfile = open(outfile,'w')
     print(outvcf.header, end="", file=outfile)
 
     for variant in sorted(calldict, key=operator.itemgetter(0)):


### PR DESCRIPTION
The `output` argument creates a file handler:
```
parser.add_argument('-o', '--output', type=argparse.FileType('w'), default=sys.stdout, help="Specify output file (default:stdout)")
```
In the `mergedfile.merge(..., outfile=outfile)` function, it shouldnt try to `open(outfile, "w")` if it's already a file handler, it should only do it if it's a filename.